### PR TITLE
Add option to name JSON feed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ plugins: [
         date_modified: new Date(node.frontmatter.updated).toISOString(),
         excerpt: node.excerpt,
       })),
+      feedFilename: "exampleFeedFilename",
       nodesPerFeedFile: 100,
     }
   }
@@ -172,9 +173,9 @@ feedMeta: {
 }
 ```
 
-### `serializeFeed` (optional
+### `serializeFeed` (optional)
 
-Include this if you want to create JSON feed files.
+Include this if you want to create JSON feed files. If you want to create multiple feed files, add multiple `gatsby-plugin-json-output` objects to `gatsby-config.js`, specify a name using the `feedFilename` field. This is useful if you want to provide feeds with different JSON structures or different data via GraphQL.
 
 This plugin uses this serializeFeed function to structure the contents of the JSON feed files. You can use this function to restructure the nested nature of `graphQLQuery`. This plugin will pass the results object of the `graphQLQuery` to your `serializeFeed` function.
 
@@ -223,6 +224,14 @@ You will find the feed files in the built assets starting from `public/feed-1.js
   "version": "https://jsonfeed.org/version/1"
 }
 ```
+
+### `feedFilename` (optional)
+
+Default name is `feed` followed by the page number. Example: `feed-1.json`.
+
+Use this option to set the name of the feed file. This is useful if you want to create multiple feed files for different JSON structures or different data via GraphQL.
+
+To create multiple feed files, you must add a `gatsby-plugin-json-output` object and options for each feed in `gatsby-config.js`.
 
 ### `nodesPerFeedFile` (optional)
 

--- a/src/helpers/checkPluginOpts.ts
+++ b/src/helpers/checkPluginOpts.ts
@@ -25,6 +25,10 @@ const checkPluginOpts = (pluginOptions: IPluginOptions): boolean => {
     throw new Error(`\`pluginOptions.serializeFeed\` should be a function of the correct structure.`);
   }
 
+  if (typeof pluginOptions.feedName !== "string" || pluginOptions.feedName === "") {
+    throw new Error(`\`pluginOptions.feedName\` should be a string that's used to name file and create file path.`);
+  }
+
   if (typeof pluginOptions.nodesPerFeedFile !== "undefined" && typeof pluginOptions.nodesPerFeedFile !== "number") {
     throw new Error(`\`pluginOptions.nodesPerFeedFile\` should be an integer.`);
   }

--- a/src/helpers/checkPluginOpts.ts
+++ b/src/helpers/checkPluginOpts.ts
@@ -25,8 +25,8 @@ const checkPluginOpts = (pluginOptions: IPluginOptions): boolean => {
     throw new Error(`\`pluginOptions.serializeFeed\` should be a function of the correct structure.`);
   }
 
-  if (typeof pluginOptions.feedName !== "string" || pluginOptions.feedName === "") {
-    throw new Error(`\`pluginOptions.feedName\` should be a string that's used to name file and create file path.`);
+  if (typeof pluginOptions.feedName !== "undefined" && typeof pluginOptions.feedName !== "string") {
+    throw new Error(`\`pluginOptions.feedName\` should be a string used to name file and create file path.`);
   }
 
   if (typeof pluginOptions.nodesPerFeedFile !== "undefined" && typeof pluginOptions.nodesPerFeedFile !== "number") {

--- a/src/helpers/checkPluginOpts.ts
+++ b/src/helpers/checkPluginOpts.ts
@@ -25,8 +25,8 @@ const checkPluginOpts = (pluginOptions: IPluginOptions): boolean => {
     throw new Error(`\`pluginOptions.serializeFeed\` should be a function of the correct structure.`);
   }
 
-  if (typeof pluginOptions.feedName !== "undefined" && typeof pluginOptions.feedName !== "string") {
-    throw new Error(`\`pluginOptions.feedName\` should be a string used to name file and create file path.`);
+  if (typeof pluginOptions.feedFilename !== "undefined" && typeof pluginOptions.feedFilename !== "string") {
+    throw new Error(`\`pluginOptions.feedFilename\` should be a string used to name feed files.`);
   }
 
   if (typeof pluginOptions.nodesPerFeedFile !== "undefined" && typeof pluginOptions.nodesPerFeedFile !== "number") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export interface IPluginOptions {
   serialize?: (results: any) => ISerializedNode[];
   feedMeta?: { [key: string]: any };
   serializeFeed?: (results: any) => ISerializedNode[];
-  feedName?: string;
+  feedFilename?: string;
   nodesPerFeedFile?: number;
 }
 
@@ -83,14 +83,14 @@ const createJsonFeedFiles = async ({
   siteUrl,
   nodes,
   nodesPerFeedFile = 100,
-  feedName = 'feed',
+  feedFilename = 'feed',
   publicPath
 }: {
   feedMeta?: { [key: string]: any };
   siteUrl: string;
   nodes: ISerializedNode[];
   nodesPerFeedFile?: number;
-  feedName?: string;
+  feedFilename?: string;
   publicPath: string;
 }) => {
   console.log("Creating JSON feed files from graphql query");
@@ -113,14 +113,14 @@ const createJsonFeedFiles = async ({
           try {
             const jsonFeed = {
               ...feedMeta,
-              feed_url: `${siteUrl}/${feedName}-1.json`,
+              feed_url: `${siteUrl}/${feedFilename}-1.json`,
               home_page_url: siteUrl,
               items: nodeChunk,
-              next_feed_url: i < nodeChunks.length - 1 ? `${siteUrl}/${feedName}-${i + 2}.json` : null,
-              previous_feed_url: i > 0 ? `${siteUrl}/${feedName}-${i}.json` : null,
+              next_feed_url: i < nodeChunks.length - 1 ? `${siteUrl}/${feedFilename}-${i + 2}.json` : null,
+              previous_feed_url: i > 0 ? `${siteUrl}/${feedFilename}-${i}.json` : null,
               version: "https://jsonfeed.org/version/1"
             };
-            writeFileSync(join(publicPath, `${feedName}-${i + 1}.json`), JSON.stringify(jsonFeed), "utf8");
+            writeFileSync(join(publicPath, `${feedFilename}-${i + 1}.json`), JSON.stringify(jsonFeed), "utf8");
             resolve();
           } catch (err) {
             reject(err);
@@ -147,7 +147,7 @@ export const start = async (graphql: any, publicPath: string, pluginOptions: IPl
 
     // Run graphql query and serialise nodes
     const siteUrl = stripTrailingSlash(pluginOptions.siteUrl);
-    const { graphQLQuery, serialize, feedMeta, serializeFeed, feedName, nodesPerFeedFile } = pluginOptions;
+    const { graphQLQuery, serialize, feedMeta, serializeFeed, feedFilename, nodesPerFeedFile } = pluginOptions;
 
     if (!serialize && !serializeFeed) {
       console.log(`No \`serialize\` or \`serializeFeed\` functions passed to ${packageName}, nothing  to do.`);
@@ -172,7 +172,7 @@ export const start = async (graphql: any, publicPath: string, pluginOptions: IPl
     if (serializeFeed) {
       const nodesForFeed: ISerializedNode[] = serializeFeed(results);
       checkNodes(nodesForFeed, true);
-      await createJsonFeedFiles({ feedMeta, nodes: nodesForFeed, nodesPerFeedFile, feedName, siteUrl, publicPath });
+      await createJsonFeedFiles({ feedMeta, nodes: nodesForFeed, nodesPerFeedFile, feedFilename, siteUrl, publicPath });
     }
   } catch (err) {
     throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export interface IPluginOptions {
   serialize?: (results: any) => ISerializedNode[];
   feedMeta?: { [key: string]: any };
   serializeFeed?: (results: any) => ISerializedNode[];
-  feedName: string;
+  feedName?: string;
   nodesPerFeedFile?: number;
 }
 
@@ -83,14 +83,14 @@ const createJsonFeedFiles = async ({
   siteUrl,
   nodes,
   nodesPerFeedFile = 100,
-  feedName,
+  feedName = 'feed',
   publicPath
 }: {
   feedMeta?: { [key: string]: any };
   siteUrl: string;
   nodes: ISerializedNode[];
   nodesPerFeedFile?: number;
-  feedName: string;
+  feedName?: string;
   publicPath: string;
 }) => {
   console.log("Creating JSON feed files from graphql query");

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export interface IPluginOptions {
   serialize?: (results: any) => ISerializedNode[];
   feedMeta?: { [key: string]: any };
   serializeFeed?: (results: any) => ISerializedNode[];
+  feedName: string;
   nodesPerFeedFile?: number;
 }
 
@@ -82,12 +83,14 @@ const createJsonFeedFiles = async ({
   siteUrl,
   nodes,
   nodesPerFeedFile = 100,
+  feedName,
   publicPath
 }: {
   feedMeta?: { [key: string]: any };
   siteUrl: string;
   nodes: ISerializedNode[];
   nodesPerFeedFile?: number;
+  feedName: string;
   publicPath: string;
 }) => {
   console.log("Creating JSON feed files from graphql query");
@@ -110,14 +113,14 @@ const createJsonFeedFiles = async ({
           try {
             const jsonFeed = {
               ...feedMeta,
-              feed_url: `${siteUrl}/feed-1.json`,
+              feed_url: `${siteUrl}/${feedName}-1.json`,
               home_page_url: siteUrl,
               items: nodeChunk,
-              next_feed_url: i < nodeChunks.length - 1 ? `${siteUrl}/feed-${i + 2}.json` : null,
-              previous_feed_url: i > 0 ? `${siteUrl}/feed-${i}.json` : null,
+              next_feed_url: i < nodeChunks.length - 1 ? `${siteUrl}/${feedName}-${i + 2}.json` : null,
+              previous_feed_url: i > 0 ? `${siteUrl}/${feedName}-${i}.json` : null,
               version: "https://jsonfeed.org/version/1"
             };
-            writeFileSync(join(publicPath, `feed-${i + 1}.json`), JSON.stringify(jsonFeed), "utf8");
+            writeFileSync(join(publicPath, `${feedName}-${i + 1}.json`), JSON.stringify(jsonFeed), "utf8");
             resolve();
           } catch (err) {
             reject(err);
@@ -144,7 +147,7 @@ export const start = async (graphql: any, publicPath: string, pluginOptions: IPl
 
     // Run graphql query and serialise nodes
     const siteUrl = stripTrailingSlash(pluginOptions.siteUrl);
-    const { graphQLQuery, serialize, feedMeta, serializeFeed, nodesPerFeedFile } = pluginOptions;
+    const { graphQLQuery, serialize, feedMeta, serializeFeed, feedName, nodesPerFeedFile } = pluginOptions;
 
     if (!serialize && !serializeFeed) {
       console.log(`No \`serialize\` or \`serializeFeed\` functions passed to ${packageName}, nothing  to do.`);
@@ -169,7 +172,7 @@ export const start = async (graphql: any, publicPath: string, pluginOptions: IPl
     if (serializeFeed) {
       const nodesForFeed: ISerializedNode[] = serializeFeed(results);
       checkNodes(nodesForFeed, true);
-      await createJsonFeedFiles({ feedMeta, nodes: nodesForFeed, nodesPerFeedFile, siteUrl, publicPath });
+      await createJsonFeedFiles({ feedMeta, nodes: nodesForFeed, nodesPerFeedFile, feedName, siteUrl, publicPath });
     }
   } catch (err) {
     throw new Error(


### PR DESCRIPTION
I wanted to name the JSON feed something other than `feed-1.json` to more closely match an API resource endpoint name that my project will replace. I made some changes to be able to provide `feedName` property to `options` object in **gatsby-node.js**. 

If `feedName` is excluded from the plugin options, it defaults to the `feed-1.json` naming convention.

Let me know if you need more info or if there's anything else I can do. Love the plugin :)

